### PR TITLE
fix: avoid mutating the shared error object in eth_signTransaction

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -191,10 +191,12 @@ export class UnWalletProvider implements Eip1193Provider {
             return;
 
           case "eth_signTransaction":
-            const err = providerRpcErrorUnsupported;
-            err.message +=
-              " (see https://github.com/MetaMask/metamask-extension/issues/2506#issuecomment-388575922)";
-            reject(err);
+            reject({
+              ...providerRpcErrorUnsupported,
+              message:
+                providerRpcErrorUnsupported.message +
+                " (see https://github.com/MetaMask/metamask-extension/issues/2506#issuecomment-388575922)",
+            });
             return;
 
           case "eth_sendTransaction":


### PR DESCRIPTION
In the `eth_signTransaction` case, `providerRpcErrorUnsupported` (a module-level `export const` in `errors.ts`) is taken by reference and then mutated via `err.message += ...`. Since it is the shared singleton, this has two side effects:

- Each call to `eth_signTransaction` appends the note again, so the message keeps growing on repeated calls (`...method (see ...) (see ...) ...`).
- The same object is rejected in the `default` case as well, so that error's message also gets polluted with the `eth_signTransaction` note after the first call.

This rejects a fresh object (spreading the shared error and overriding `message`) instead of mutating the shared one. `name` / `code` are preserved.